### PR TITLE
refactor: remove bedrock support

### DIFF
--- a/src/components/onboarding/JoinSteps.tsx
+++ b/src/components/onboarding/JoinSteps.tsx
@@ -31,8 +31,7 @@ const JoinSteps: React.FC = () => {
         </div>
       </Instruction>
       <Instruction step="3">
-        Enter <strong>tristansmp.com</strong> (Java) or{" "}
-        <strong>mc.tristansmp.com</strong> (Bedrock) into Server Address
+        Enter <strong>tristansmp.com</strong> (Java) into Server Address
         <div className="mt-1 max-w-[24rem]">
           <Image
             src={imgMinecraftServerAddress}

--- a/src/components/onboarding/LinkMinecraftStage.tsx
+++ b/src/components/onboarding/LinkMinecraftStage.tsx
@@ -8,20 +8,11 @@ const LinkMinecraftStage: React.FC<{
   setUsername: (username: string) => void;
   next: () => void;
 }> = ({ setUsername, username, next }) => {
-  const [bedrock, setBedrock] = useState(false);
   const [inputUsername, setInputUsername] = useState(username);
 
   const profile = trpc.onboarding.findPlayer.useQuery({
-    mcUsername: bedrock ? `.${inputUsername}` : inputUsername,
+    mcUsername: inputUsername,
   });
-
-  useEffect(() => {
-    if (inputUsername.startsWith(".")) {
-      setBedrock(true);
-    } else {
-      setBedrock(false);
-    }
-  }, [inputUsername]);
 
   return (
     <div>
@@ -35,7 +26,7 @@ const LinkMinecraftStage: React.FC<{
           </p>
 
           <div>
-            <div className="input-group py-5">
+            <div className="pt-2">
               <input
                 type="text"
                 placeholder="Minecraft username"
@@ -43,24 +34,17 @@ const LinkMinecraftStage: React.FC<{
                 onChange={(e) => setInputUsername(e.target.value)}
                 className="input-bordered input mt-5 -ml-0.5"
               />
-
-              <button
-                onClick={() => {
-                  setBedrock(!bedrock);
-                }}
-                className="btn btn-secondary mt-5 -ml-0.5 w-1/3 max-w-fit"
-              >
-                {bedrock ? "Bedrock" : "Java"}
-              </button>
             </div>
 
-            <br />
+            <div className="mt-2 mb-5 text-xs opacity-60">
+              Only Java Edition accounts are supported.
+            </div>
 
             <button
               onClick={() => {
-                setUsername(bedrock ? `.${inputUsername}` : inputUsername);
+                setUsername(inputUsername);
               }}
-              className={`btn btn-primary ${
+              className={`btn-primary btn ${
                 profile.isLoading && username !== "" ? "loading" : ""
               }`}
               disabled={
@@ -112,7 +96,7 @@ const LinkMinecraftStage: React.FC<{
             continue.
           </p>
           <button
-            className="btn btn-primary mt-3"
+            className="btn-primary btn mt-3"
             onClick={
               profile.data.online
                 ? next

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -24,9 +24,9 @@ const Home: NextPage = () => {
                 .
               </h1>
               <p className="my-5 py-6 text-lg">
-                Tristan SMP is a semi-vanilla Minecraft server for both Java and
-                Bedrock hosted in Sydney that offers an immersive and unique
-                experience to its players.
+                Tristan SMP is a semi-vanilla Minecraft server for Java hosted
+                in Sydney that offers an immersive and unique experience to its
+                players.
               </p>
               <Link href="/blog/join" className="btn-primary btn">
                 Get Started


### PR DESCRIPTION
This PR removes Bedrock support when creating an application and any references for having Bedrock support on the website (including docs).

There are still references to having Bedrock support on other sources, such as the Discord server and Notion blog posts.